### PR TITLE
Add task proto and build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "codex"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[dependencies]
+prost = "0.11"
+tonic = { version = "0.8", default-features = false, features = ["prost"] }
+
+[build-dependencies]
+tonic-build = "0.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    tonic_build::configure()
+        .build_server(false)
+        .compile(&["proto/task/v1/task.proto"], &["proto"]).unwrap();
+}

--- a/proto/task/v1/task.proto
+++ b/proto/task/v1/task.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package task.v1;
+
+// Represents a task with an id and name.
+message Task {
+  string id = 1;
+  string name = 2;
+}
+
+// Request to create a task.
+message CreateTaskRequest {
+  Task task = 1;
+}
+
+// Response returned after creating a task.
+message CreateTaskResponse {
+  Task task = 1;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod task {
+    include!(concat!(env!("OUT_DIR"), "/task.v1.rs"));
+}


### PR DESCRIPTION
## Summary
- define task protobuf under `proto/task/v1/task.proto`
- generate prost code via `build.rs`
- set up Cargo project using tonic
- expose generated module in `src/lib.rs`

## Testing
- `cargo build` *(fails: could not fetch crates)*