### PR TITLE
Add gRPC service and HTTP routes for tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "codex"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[dependencies]
+axum = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tonic = { version = "0.11", features = ["transport"] }
+prost = "0.12"
+thiserror = "1"
+
+[build-dependencies]
+tonic-build = "0.11"
+prost-build = "0.12"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/task.proto")?;
+    Ok(())
+}

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package task;
+
+service TaskService {
+  rpc CreateTask (CreateTaskRequest) returns (Task) {}
+  rpc ListTasks (ListTasksRequest) returns (TaskList) {}
+}
+
+message CreateTaskRequest {
+  string title = 1;
+}
+
+message ListTasksRequest {}
+
+message Task {
+  int32 id = 1;
+  string title = 2;
+}
+
+message TaskList {
+  repeated Task tasks = 1;
+}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -1,0 +1,29 @@
+use tonic::{Request, Response, Status};
+
+use crate::task_manager::{TaskManager, Task};
+use crate::task::{task_service_server::{TaskService, TaskServiceServer}, *};
+
+pub fn service(manager: TaskManager) -> TaskServiceServer<MyTaskService> {
+    TaskServiceServer::new(MyTaskService { manager })
+}
+
+pub struct MyTaskService {
+    manager: TaskManager,
+}
+
+#[tonic::async_trait]
+impl TaskService for MyTaskService {
+    async fn create_task(&self, request: Request<CreateTaskRequest>) -> Result<Response<TaskProto>, Status> {
+        let title = request.into_inner().title;
+        let task = self.manager.create_task(title);
+        let reply = TaskProto { id: task.id, title: task.title };
+        Ok(Response::new(reply))
+    }
+
+    async fn list_tasks(&self, _request: Request<ListTasksRequest>) -> Result<Response<TaskList>, Status> {
+        let tasks = self.manager.list_tasks();
+        let tasks_proto = tasks.into_iter().map(|t| TaskProto { id: t.id, title: t.title }).collect();
+        let reply = TaskList { tasks: tasks_proto };
+        Ok(Response::new(reply))
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,23 @@
+use axum::{extract::State, routing::{get, post}, Json, Router};
+use crate::task_manager::{TaskManager, Task};
+
+#[derive(serde::Deserialize)]
+struct CreateTaskPayload {
+    title: String,
+}
+
+pub fn router(manager: TaskManager) -> Router {
+    Router::new()
+        .route("/tasks", post(create_task).get(list_tasks))
+        .with_state(manager)
+}
+
+async fn create_task(State(manager): State<TaskManager>, Json(payload): Json<CreateTaskPayload>) -> Json<Task> {
+    let task = manager.create_task(payload.title);
+    Json(task)
+}
+
+async fn list_tasks(State(manager): State<TaskManager>) -> Json<Vec<Task>> {
+    let tasks = manager.list_tasks();
+    Json(tasks)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,31 @@
+mod task_manager;
+mod grpc;
+mod http;
+
+use task_manager::TaskManager;
+use axum::Server as AxumServer;
+use tonic::transport::Server;
+use crate::grpc::service;
+
+use std::net::SocketAddr;
+
+pub mod task {
+    tonic::include_proto!("task");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manager = TaskManager::new();
+
+    let grpc_service = service(manager.clone());
+    let http_router = http::router(manager.clone());
+
+    let grpc_addr: SocketAddr = "0.0.0.0:50051".parse()?;
+    let http_addr: SocketAddr = "0.0.0.0:3000".parse()?;
+
+    let grpc_server = Server::builder().add_service(grpc_service).serve(grpc_addr);
+    let http_server = AxumServer::bind(&http_addr).serve(http_router.into_make_service());
+
+    tokio::try_join!(grpc_server, http_server)?;
+    Ok(())
+}

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -1,0 +1,31 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+pub struct TaskManager {
+    inner: Arc<Mutex<Vec<Task>>>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct Task {
+    pub id: i32,
+    pub title: String,
+}
+
+impl TaskManager {
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    pub fn create_task(&self, title: String) -> Task {
+        let mut tasks = self.inner.lock().unwrap();
+        let id = tasks.len() as i32 + 1;
+        let task = Task { id, title };
+        tasks.push(task.clone());
+        task
+    }
+
+    pub fn list_tasks(&self) -> Vec<Task> {
+        let tasks = self.inner.lock().unwrap();
+        tasks.clone()
+    }
+}


### PR DESCRIPTION
## Summary
- set up Cargo project with tonic and axum
- add protobuf definition for tasks gRPC service
- implement in-memory `TaskManager` business logic
- expose gRPC service
- expose HTTP `/tasks` POST and GET routes that use same logic
- run both HTTP and gRPC servers in main

## Testing
- `cargo test` *(fails: failed to fetch crates)*