### PR TITLE
Create taskd workspace

### DIFF
--- a/taskd/Cargo.toml
+++ b/taskd/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["taskd-core", "taskd-api"]
+resolver = "2"

--- a/taskd/taskd-api/Cargo.toml
+++ b/taskd/taskd-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "taskd-api"
+version = "0.1.0"
+edition = "2024"
+build = "build.rs"
+
+[dependencies]
+axum = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tonic = { version = "0.11", features = ["transport"] }
+tracing = "0.1"
+taskd-core = { path = "../taskd-core" }
+
+[build-dependencies]
+prost-build = "0.12"

--- a/taskd/taskd-api/build.rs
+++ b/taskd/taskd-api/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Placeholder build script for prost-build
+    let _ = prost_build::Config::new();
+}

--- a/taskd/taskd-api/src/lib.rs
+++ b/taskd/taskd-api/src/lib.rs
@@ -1,0 +1,15 @@
+use axum::{routing::get, Router};
+use tonic::transport::Server;
+
+use taskd_core::Repository;
+
+/// Build a simple HTTP router.
+pub fn router() -> Router {
+    Router::new().route("/health", get(|| async { "ok" }))
+}
+
+/// Placeholder gRPC server function.
+pub async fn start_grpc(addr: std::net::SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
+    Server::builder().serve(addr).await?;
+    Ok(())
+}

--- a/taskd/taskd-core/Cargo.toml
+++ b/taskd/taskd-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "taskd-core"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+sqlx = { version = "0.7", features = ["runtime-tokio", "sqlite"] }
+tracing = "0.1"

--- a/taskd/taskd-core/src/lib.rs
+++ b/taskd/taskd-core/src/lib.rs
@@ -1,0 +1,17 @@
+use sqlx::SqlitePool;
+use tracing::info;
+
+/// Simple repository wrapper around a [`SqlitePool`].
+pub struct Repository {
+    pool: SqlitePool,
+}
+
+impl Repository {
+    /// Establish a new connection pool.
+    pub async fn new(database_url: &str) -> sqlx::Result<Self> {
+        let pool = SqlitePool::connect(database_url).await?;
+        info!("database connected");
+        Ok(Self { pool })
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a new `taskd` Cargo workspace
- define `taskd-core` and `taskd-api` crates
- add axum, tonic, prost-build, sqlx, and tracing dependencies

## Testing
- `cargo check -p taskd-core -p taskd-api` *(fails: Could not connect to server)*