### PR TITLE
Implement PostgresStore in new taskd_core crate

### DIFF
--- a/taskd_core/Cargo.toml
+++ b/taskd_core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "taskd_core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sqlx = { version = "0.7", features = ["runtime-tokio", "postgres", "macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }
+thiserror = "1"

--- a/taskd_core/migrations/0001_create_tasks.sql
+++ b/taskd_core/migrations/0001_create_tasks.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS tasks (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/taskd_core/src/lib.rs
+++ b/taskd_core/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod store;
+
+pub use store::{PostgresStore, StoreError, Task};

--- a/taskd_core/src/store.rs
+++ b/taskd_core/src/store.rs
@@ -1,0 +1,74 @@
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use thiserror::Error;
+
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
+pub struct Task {
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Debug, Error)]
+pub enum StoreError {
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+}
+
+pub struct PostgresStore {
+    pool: PgPool,
+}
+
+impl PostgresStore {
+    pub async fn new(database_url: &str) -> Result<Self, StoreError> {
+        let pool = PgPoolOptions::new()
+            .connect(database_url)
+            .await?;
+        sqlx::migrate!("migrations").run(&pool).await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn add_task(&self, name: &str) -> Result<Task, StoreError> {
+        let rec = sqlx::query_as::<_, Task>(
+            "INSERT INTO tasks(name) VALUES ($1) RETURNING id, name",
+        )
+        .bind(name)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(rec)
+    }
+
+    pub async fn get_task(&self, id: i32) -> Result<Option<Task>, StoreError> {
+        let rec = sqlx::query_as::<_, Task>(
+            "SELECT id, name FROM tasks WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(rec)
+    }
+
+    pub async fn list_tasks(&self, limit: Option<i64>) -> Result<Vec<Task>, StoreError> {
+        let tasks = if let Some(limit) = limit {
+            sqlx::query_as::<_, Task>(
+                "SELECT id, name FROM tasks ORDER BY id LIMIT $1",
+            )
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, Task>("SELECT id, name FROM tasks ORDER BY id")
+                .fetch_all(&self.pool)
+                .await?
+        };
+        Ok(tasks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn migrations_compile() {
+        let _ = sqlx::migrate!("migrations");
+    }
+}


### PR DESCRIPTION
## Summary
- add new `taskd_core` crate
- implement `store::PostgresStore` using sqlx
- provide initial migration for `tasks` table

## Testing
- `cargo test` *(fails: failed to fetch crates)*