### PR TITLE
Add taskd Helm chart

### DIFF
--- a/charts/taskd/Chart.yaml
+++ b/charts/taskd/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: taskd
+description: A Helm chart for the taskd service
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/charts/taskd/templates/_helpers.tpl
+++ b/charts/taskd/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "taskd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "taskd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}

--- a/charts/taskd/templates/deployment.yaml
+++ b/charts/taskd/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "taskd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "taskd.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "taskd.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "taskd.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ include "taskd.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            - name: DATABASE_URL
+              value: "postgres://postgres@localhost/db"

--- a/charts/taskd/templates/hpa.yaml
+++ b/charts/taskd/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "taskd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "taskd.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "taskd.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/taskd/templates/service.yaml
+++ b/charts/taskd/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "taskd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "taskd.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "taskd.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: grpc

--- a/charts/taskd/values.yaml
+++ b/charts/taskd/values.yaml
@@ -1,0 +1,16 @@
+replicaCount: 1
+
+image:
+  repository: myrepo/taskd
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 50051
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
## Summary
- add Helm chart for taskd with Deployment, Service and HPA

## Testing
- `cargo test` *(fails: failed to download crates)*
- `helm lint charts/taskd`