### PR TITLE
Add development helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: cargo fmt --all
+        language: system
+        files: \.(rs)$
+      - id: clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        pass_filenames: false
+      - id: buf-lint
+        name: buf lint
+        entry: buf lint
+        language: system
+        pass_filenames: false
+      - id: helm-lint
+        name: helm lint
+        entry: helm lint charts/
+        language: system
+        pass_filenames: false
+

--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ python -m taskd_api.service
 The service listens on port `50051` by default and requires a running
 PostgreSQL database configured via the `DATABASE_URL` environment
 variable.
+
+## Development
+
+Use `just` to run common tasks. The `dev` recipe starts the application and
+`ci` runs the checks used in CI:
+
+```bash
+just dev
+just ci
+```
+
+Pre-commit hooks are configured in `.pre-commit-config.yaml` and include
+`rustfmt`, `clippy`, `buf`, and Helm linting.
+
+

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,5 @@
+version: v1
+lint:
+  use:
+    - DEFAULT
+

--- a/justfile
+++ b/justfile
@@ -1,0 +1,17 @@
+# Development and CI tasks managed by just
+
+# Run the application in development mode
+# Usage: `just dev`
+
+dev:
+    cargo run
+
+# Run checks used in CI pipelines
+# Usage: `just ci`
+ci:
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test
+    buf lint
+    helm lint charts/
+


### PR DESCRIPTION
## Summary
- add `justfile` with `dev` and `ci` recipes
- configure pre-commit hooks for rustfmt, clippy, buf and Helm
- add minimal `buf.yaml`
- document new dev instructions

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: Could not connect to server)*
- `cargo test` *(fails: Could not connect to server)*