### PR TITLE
Add OTLP tracing and monitoring examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,13 @@ prost = "0.12"
 # error handling
 thiserror = "1"
 
+# tracing
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-opentelemetry = "0.23"
+opentelemetry = { version = "0.22", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.15", features = ["tonic", "tls"] }
+
 [build-dependencies]
 # generates Rust types from .proto files
 prost-build = "0.12"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ python -m taskd_api.service
 The service listens on port `50051` by default and requires a running
 PostgreSQL database configured via the `DATABASE_URL` environment
 variable.
+
+## Observability
+
+Tracing is exported using the OTLP protocol. Example Grafana dashboard and
+a Prometheus `ServiceMonitor` can be found in the `monitoring/` directory.

--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -1,0 +1,12 @@
+{
+  "title": "Codex Tasks",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "gRPC Requests",
+      "targets": [
+        {"expr": "rate(grpc_server_handled_total[5m])", "legendFormat": "{{method}}"}
+      ]
+    }
+  ]
+}

--- a/monitoring/servicemonitor.yaml
+++ b/monitoring/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: codex
+  labels:
+    app: codex
+spec:
+  selector:
+    matchLabels:
+      app: codex
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,10 @@
-use axum::{extract::State, routing::{get, post}, Json, Router};
-use crate::task_manager::{TaskManager, Task};
+use crate::task_manager::{Task, TaskManager};
+use axum::{
+    extract::State,
+    routing::{get, post},
+    Json, Router,
+};
+use tracing::instrument;
 
 #[derive(serde::Deserialize)]
 struct CreateTaskPayload {
@@ -12,11 +17,16 @@ pub fn router(manager: TaskManager) -> Router {
         .with_state(manager)
 }
 
-async fn create_task(State(manager): State<TaskManager>, Json(payload): Json<CreateTaskPayload>) -> Json<Task> {
+#[instrument]
+async fn create_task(
+    State(manager): State<TaskManager>,
+    Json(payload): Json<CreateTaskPayload>,
+) -> Json<Task> {
     let task = manager.create_task(payload.title);
     Json(task)
 }
 
+#[instrument]
 async fn list_tasks(State(manager): State<TaskManager>) -> Json<Vec<Task>> {
     let tasks = manager.list_tasks();
     Json(tasks)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,35 @@
-mod task_manager;
 mod grpc;
 mod http;
+mod task_manager;
 
-use task_manager::TaskManager;
-use axum::Server as AxumServer;
-use tonic::transport::Server;
 use crate::grpc::service;
+use axum::Server as AxumServer;
+use task_manager::TaskManager;
+use tonic::transport::Server;
+use tracing::info;
+
+use opentelemetry::runtime::Tokio;
+use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry_otlp::WithExportConfig;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let exporter = opentelemetry_otlp::new_exporter().tonic();
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(exporter)
+        .install_batch(Tokio)?;
+
+    let otel_layer = OpenTelemetryLayer::new(tracer);
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(otel_layer)
+        .try_init()?;
+    Ok(())
+}
 
 use std::net::SocketAddr;
 
@@ -15,6 +39,7 @@ pub mod task {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing()?;
     let manager = TaskManager::new();
 
     let grpc_service = service(manager.clone());
@@ -23,9 +48,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let grpc_addr: SocketAddr = "0.0.0.0:50051".parse()?;
     let http_addr: SocketAddr = "0.0.0.0:3000".parse()?;
 
+    info!("starting gRPC server on {}", grpc_addr);
+    info!("starting HTTP server on {}", http_addr);
+
     let grpc_server = Server::builder().add_service(grpc_service).serve(grpc_addr);
     let http_server = AxumServer::bind(&http_addr).serve(http_router.into_make_service());
 
     tokio::try_join!(grpc_server, http_server)?;
+    opentelemetry::global::shutdown_tracer_provider();
     Ok(())
 }

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use tracing::instrument;
 
 #[derive(Clone, Default)]
 pub struct TaskManager {
@@ -13,9 +14,12 @@ pub struct Task {
 
 impl TaskManager {
     pub fn new() -> Self {
-        Self { inner: Arc::new(Mutex::new(Vec::new())) }
+        Self {
+            inner: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 
+    #[instrument]
     pub fn create_task(&self, title: String) -> Task {
         let mut tasks = self.inner.lock().unwrap();
         let id = tasks.len() as i32 + 1;
@@ -24,6 +28,7 @@ impl TaskManager {
         task
     }
 
+    #[instrument]
     pub fn list_tasks(&self) -> Vec<Task> {
         let tasks = self.inner.lock().unwrap();
         tasks.clone()


### PR DESCRIPTION
## Summary
- instrument TaskManager, gRPC and HTTP handlers with tracing
- export traces via OTLP in `init_tracing`
- document monitoring resources in README
- add sample Grafana dashboard JSON and ServiceMonitor

## Testing
- `cargo fmt --check`
- `cargo test` *(fails: could not download crates)*